### PR TITLE
OSX uses MAP_ANON instead of MAP_ANONYMOUS

### DIFF
--- a/src/afl_cov_rt.c
+++ b/src/afl_cov_rt.c
@@ -23,6 +23,11 @@
 #include <unistd.h>
 #include <stdlib.h>
 
+/* OSX uses MAP_ANON instead of MAP_ANONYMOUS */
+#ifndef MAP_ANONYMOUS
+#  define MAP_ANONYMOUS MAP_ANON
+#endif
+
 /* Globals. */
 unsigned char *__afl_area_ptr;
 unsigned short __afl_prev_loc;


### PR DESCRIPTION
Was running into this issue when compiling on OSX:

```
error: use of undeclared identifier 'MAP_ANONYMOUS'
```

Did a Google search and came across:

https://j.ee.washington.edu/trac/gmtk/ticket/371

Applied that patch to the .c file and things seem to work